### PR TITLE
Update clean.ps1

### DIFF
--- a/clean.ps1
+++ b/clean.ps1
@@ -2,7 +2,10 @@
 # Delete Junk
 
 ls -Recurse -include 'bin','obj','packages' |
-  foreach { 
-    remove-item $_ -recurse -force
-    write-host deleted $_
+  foreach {
+    $currentItem = $_
+    if ((ls $currentItem.Directory | ?{ $_.Name -Like "*.sln" -or $_.Name -Like "*.*proj" }).Length -gt 0) {
+      remove-item $currentItem -recurse -force
+      write-host deleted $currentItem
+    }
 }


### PR DESCRIPTION
Removing everything with 'bin', 'obj' or 'packages' through the whole directory structure makes a few assumptions that those folders aren't present anywhere else... For example I ran this on the actual NuGetGallery solution, which has ASP.NET MVC Views/Packages area, so in that case did not want to delete Packages. Ideally, just want to delete bin / obj / packages folders on the same level as a .sln or a .csproj or .*proj file types.
